### PR TITLE
fixing zigbee entering in bootloader mode

### DIFF
--- a/admobilize_remove_console.py
+++ b/admobilize_remove_console.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python2
+
+f = open('/boot/cmdline.txt', 'r')
+parameters = f.read().split(" ")
+f.close()
+
+new_parameters = ""
+for item in parameters:
+  if item.find("console") == -1:
+    new_parameters = new_parameters + " " + item
+
+f = open('/boot/cmdline.txt', 'w')
+f.write(new_parameters)
+

--- a/boot_modifications.txt
+++ b/boot_modifications.txt
@@ -4,3 +4,4 @@ dtparam=gpio_in_pin=16
 dtparam=gpio_in_pull=down
 dtparam=spi=on
 start_x=1
+enable_uart=1

--- a/debian/matrix-creator-init.install
+++ b/debian/matrix-creator-init.install
@@ -10,6 +10,7 @@ firmware_info usr/share/admobilize/matrix-creator
 mcu_firmware.version usr/share/admobilize/matrix-creator
 boot_modifications.txt usr/share/admobilize/matrix-creator/config
 admobilize_edit_setting.py usr/share/admobilize/matrix-creator
+admobilize_remove_console.py usr/share/admobilize/matrix-creator
 matrix-creator-firmware.service lib/systemd/system
 matrix-creator-reset-jtag usr/bin
 creator-mics.conf etc/modules-load.d

--- a/debian/postinst
+++ b/debian/postinst
@@ -18,7 +18,4 @@ echo "Changing LIRC configuration"
 cp -n /etc/lirc/hardware.conf /etc/lirc/hardware.conf.before.creator.init
 cp /usr/share/admobilize/matrix-creator/lirc_hardware.conf /etc/lirc/hardware.conf
 
-# Allow programming of MCU in case of firmware updates
-rm -f /usr/share/admobilize/matrix-creator/sam3-program.bash.done
-
 echo "Please restart your Raspberry Pi after installation"

--- a/debian/postinst
+++ b/debian/postinst
@@ -11,6 +11,9 @@ systemctl enable matrix-creator-firmware
 echo "Enabling IR and SPI"
 cp /boot/config.txt /boot/config.txt.bk && /usr/share/admobilize/matrix-creator/admobilize_edit_setting.py /boot/config.txt.bk /usr/share/admobilize/matrix-creator/config/boot_modifications.txt > /boot/config.txt
 
+echo "Enabling UART"
+/usr/share/admobilize/matrix-creator/admobilize_remove_console.py
+
 echo "Changing LIRC configuration"
 cp -n /etc/lirc/hardware.conf /etc/lirc/hardware.conf.before.creator.init
 cp /usr/share/admobilize/matrix-creator/lirc_hardware.conf /etc/lirc/hardware.conf

--- a/em358-program.bash
+++ b/em358-program.bash
@@ -5,6 +5,11 @@ LOG_FILE=/tmp/em358-program.log
 
 function super_reset()
 {
+  # gpio19 - EM358 nBOOTMODE (active low)
+  # gpio18 - mcu power
+  # gpio20 - EM_NRST - EM3588 RESET (active low)
+  # gpio23 - EM3588 POWER ENABLE
+
   # Set out mode  
   for j in 18 19 20 23
   do
@@ -49,6 +54,12 @@ function try_program() {
   echo $RES
 }
 
+function enable_program() {
+  
+  echo 1 > /sys/class/gpio/gpio19/value
+  echo "Running the program instead of the bootloader" 
+
+}
 
 for i in 4 17 18 19 20 22 23 27
 do
@@ -64,7 +75,6 @@ SUM=$(md5sum /tmp/em358_dump | awk  '{printf $1}')
 if [ "${CHECKSUM}" = "${SUM}" ]
 then 
     echo "EM358 MCU was programmed before. Not programming it again."
-    exit 0
 fi
 
 super_reset
@@ -76,10 +86,9 @@ while [  $count -lt 10 ]; do
 
   if [ "$TEST" == "1" ];
   then
-        echo "****  EM358 MCU programmed!"
+	echo "****  EM358 MCU programmed!"
         break
    fi
   let count=count+1
 done
-
-
+enable_program

--- a/em358-program.bash
+++ b/em358-program.bash
@@ -56,8 +56,9 @@ function try_program() {
 
 function enable_program() {
   
-  echo 0 > /sys/class/gpio/gpio19/value
   echo 1 > /sys/class/gpio/gpio19/value
+  echo 0 > /sys/class/gpio/gpio20/value
+  echo 1 > /sys/class/gpio/gpio20/value
 
   echo "Running the program instead of the bootloader" 
 
@@ -70,6 +71,8 @@ do
     echo $i > /sys/class/gpio/export
   fi
 done
+
+super_reset
 
 check_flash_status
 SUM=$(md5sum /tmp/em358_dump | awk  '{printf $1}')

--- a/em358-program.bash
+++ b/em358-program.bash
@@ -56,7 +56,9 @@ function try_program() {
 
 function enable_program() {
   
+  echo 0 > /sys/class/gpio/gpio19/value
   echo 1 > /sys/class/gpio/gpio19/value
+
   echo "Running the program instead of the bootloader" 
 
 }
@@ -72,9 +74,12 @@ done
 check_flash_status
 SUM=$(md5sum /tmp/em358_dump | awk  '{printf $1}')
 
+
 if [ "${CHECKSUM}" = "${SUM}" ]
 then 
+    enable_program
     echo "EM358 MCU was programmed before. Not programming it again."
+    exit 0
 fi
 
 super_reset

--- a/sam3-program.bash
+++ b/sam3-program.bash
@@ -116,4 +116,5 @@ while [  $count -lt 30 ]; do
   let count=count+1
 done
 echo "**** Could not program SAM3 MCU, you must be check the logfile ${LOG_FILE}"
+enable_program
 exit 1

--- a/sam3-program.bash
+++ b/sam3-program.bash
@@ -101,7 +101,7 @@ then
   echo "SAM3 MCU was programmed before. Not programming it again."
   exit 0
 fi
-
+enable_program
 count=0
 while [  $count -lt 30 ]; do
   TEST=$(try_program)
@@ -116,5 +116,4 @@ while [  $count -lt 30 ]; do
   let count=count+1
 done
 echo "**** Could not program SAM3 MCU, you must be check the logfile ${LOG_FILE}"
-enable_program
 exit 1

--- a/sam3-program.bash
+++ b/sam3-program.bash
@@ -4,7 +4,12 @@ LOG_FILE=/tmp/sam3-program.log
 
 function super_reset()
 {
-  # Set out mode  
+  # gpio19 - EM358 nBOOTMODE (active low)
+  # gpio18 - mcu power
+  # gpio20 - EM_NRST - EM3588 RESET (active low)
+  # gpio23 - EM3588 POWER ENABLE
+
+  # Set out mode
   for j in 18 19 20 23
   do
     echo out > /sys/class/gpio/gpio$j/direction
@@ -15,9 +20,10 @@ function super_reset()
     echo in > /sys/class/gpio/gpio$k/direction
   done
 
-  #Power EM_358 OFF 
-  echo 1 > /sys/class/gpio/gpio18/value
+  # Running the program instead of the bootloader
   echo 1 > /sys/class/gpio/gpio19/value
+
+  echo 1 > /sys/class/gpio/gpio18/value
   echo 1 > /sys/class/gpio/gpio20/value
   echo 0 > /sys/class/gpio/gpio23/value
   sleep 0.5
@@ -27,15 +33,11 @@ function super_reset()
   sleep 0.5
 
   echo 0 > /sys/class/gpio/gpio18/value
-  echo 0 > /sys/class/gpio/gpio19/value
   echo 0 > /sys/class/gpio/gpio20/value
 
   sleep 0.5
   echo 1 > /sys/class/gpio/gpio18/value
   echo 1 > /sys/class/gpio/gpio20/value
-
-  sleep 0.5
-  echo 1 > /sys/class/gpio/gpio19/value
 }
 
 function reset_mcu() {

--- a/sam3-program.bash
+++ b/sam3-program.bash
@@ -9,7 +9,7 @@ function super_reset()
   # gpio20 - EM_NRST - EM3588 RESET (active low)
   # gpio23 - EM3588 POWER ENABLE
 
-  # Set out mode
+  # Set out mode  
   for j in 18 19 20 23
   do
     echo out > /sys/class/gpio/gpio$j/direction
@@ -20,10 +20,9 @@ function super_reset()
     echo in > /sys/class/gpio/gpio$k/direction
   done
 
-  # Running the program instead of the bootloader
-  echo 1 > /sys/class/gpio/gpio19/value
-
+  #Power EM_358 OFF 
   echo 1 > /sys/class/gpio/gpio18/value
+  echo 1 > /sys/class/gpio/gpio19/value
   echo 1 > /sys/class/gpio/gpio20/value
   echo 0 > /sys/class/gpio/gpio23/value
   sleep 0.5
@@ -33,11 +32,15 @@ function super_reset()
   sleep 0.5
 
   echo 0 > /sys/class/gpio/gpio18/value
+  echo 0 > /sys/class/gpio/gpio19/value
   echo 0 > /sys/class/gpio/gpio20/value
 
   sleep 0.5
   echo 1 > /sys/class/gpio/gpio18/value
   echo 1 > /sys/class/gpio/gpio20/value
+
+  sleep 0.5
+  echo 1 > /sys/class/gpio/gpio19/value
 }
 
 function reset_mcu() {
@@ -60,6 +63,13 @@ function try_program() {
   
   sleep 0.5
   reset_mcu  
+}
+
+function enable_program() {
+  echo 1 > /sys/class/gpio/gpio19/value
+  echo 0 > /sys/class/gpio/gpio20/value
+  echo 1 > /sys/class/gpio/gpio20/value
+  echo "Running the program instead of the bootloader" 
 }
 
 function check_firmware() {
@@ -86,6 +96,8 @@ reset_mcu
 CHECK=$(check_firmware)
 if [ "$CHECK" == "1" ]
 then
+  reset_mcu
+  enable_program
   echo "SAM3 MCU was programmed before. Not programming it again."
   exit 0
 fi


### PR DESCRIPTION
The zigbee chip was entering in bootloader mode instead of runing the actual firmware. 
Changed the gpio19 - EM358 nBOOTMODE (active low) to HIGH while the chip Resets.