### PR TITLE
Fix libmatrixio-creator-hal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+matrixio-creator-init (0.4.7) unstable; urgency=medium
+
+  * Fix libmatrixio-creator-hal as a dependency.
+
+ --  Kevin Patino <kevin.patino@admobilize.com>  Mon, 2 Apr 2018 15:00:00 +0000
+
 matrixio-creator-init (0.4.6) unstable; urgency=medium
 
   * Support 96KHz in MATRIX Devices.

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Package: matrixio-creator-init
 Conflicts: matrix-creator-init
 Replaces: matrix-creator-init
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, matrixio-openocd, wiringpi, matrixio-xc3sprog, python-pip
+Depends: ${shlibs:Depends}, ${misc:Depends},libmatrixio-creator-hal, matrixio-openocd, wiringpi, matrixio-xc3sprog, python-pip
 Description: Install scripts that can program the MATRIX Creator FPGA and SAM3 IMU.
  Install scripts that can program the MATRIX Creator FPGA and SAM3 IMU.


### PR DESCRIPTION
Bug Fix: Set libmatrixio-creator-hal as a dependency.
