### PR TITLE
Fix script to add new setings in /boot/config.txt

### DIFF
--- a/boot_modifications.txt
+++ b/boot_modifications.txt
@@ -1,7 +1,3 @@
-dtparam=gpio_out_pin=13
-dtparam=gpio_in_pin=16
-dtparam=gpio_in_pull=down
 dtparam=spi=on
 start_x=1
 enable_uart=1
-dtoverlay=spi0-cs,cs1_pin=12

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-matrixio-creator-init (0.4.14) unstable; urgency=medium
+matrixio-creator-init (0.4.15) unstable; urgency=medium
+
+  * Fix script to add new setings in /boot/config.txt
+
+ --  Leonardo Urrego <leonardo.urrego@admobilize.com>  Thu, 27 Jun 2019 15:00:00 +0000
+ 
+ matrixio-creator-init (0.4.14) unstable; urgency=medium
 
   * Buster support added (Jessie deprecated). 
 

--- a/matrixlabs_edit_settings.py
+++ b/matrixlabs_edit_settings.py
@@ -42,15 +42,7 @@ for original in ORIGINAL_LINES:
         print original[1]
     else:
         key, value = key_and_value(original)
-        if key in KEYS_TO_CHANGE and KEYS_TO_CHANGE[key] != value:
-            new_value = KEYS_TO_CHANGE[key]
-            print '# previous value for {} was {}.'.format(key,
-                                                           value,
-                                                           new_value),
-            print 'Changed by matrixlabs_edit_settings.py'
-            print '{}={}'.format(key, new_value)
-            del  KEYS_TO_CHANGE[key]
-        elif key in KEYS_TO_CHANGE and KEYS_TO_CHANGE[key] == value:
+        if key in KEYS_TO_CHANGE and KEYS_TO_CHANGE[key] == value:
             print '{}={}'.format(key, KEYS_TO_CHANGE[key])
             del KEYS_TO_CHANGE[key]
         else:
@@ -60,5 +52,5 @@ if len(KEYS_TO_CHANGE):
     print '# Lines added by matrixlabs_edit_settings.py.'
     print '# Commented definitions of the settings might be above.'
 
-for key  in sorted(KEYS_TO_CHANGE):
-    print '{}={}'.format(key, KEYS_TO_CHANGE[key])
+    for key  in sorted(KEYS_TO_CHANGE):
+        print '{}={}'.format(key, KEYS_TO_CHANGE[key])


### PR DESCRIPTION
Remove some old settings in boot_modifications.txt and fix script matrixlabs_edit_settings.py to add properly dtoverlay settings in /boot/config.txt